### PR TITLE
allow users to specify additional form settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Whats New:
 * Along with the concept of custom form submission classes.
 * Fields are now added via a StreamField and you can define your own like ReCAPTCHA or RegexFields.
 * You can easily overwrite fields to add things like widget attributes.
+* You can define a model that will allow you to save additional settings for each form.
 * The form submission is processed via hooks instead of baked into the models.
 * You can create as many form submission hooks as you like to process, email etc the data as you wish. These will be available to all forms that you can enable/disable at will.
 * Files can now be uploaded and are stored along with the submission using the default storage.

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ What else is included?
 *  Form submissions are controlled via hooks meaning you can easily create things like emailing the submission which you can turn on and off on each form.
 *  Fields can easily be added to the form from your own code such as Recaptcha or a Regex Field.
 *  The default set of fields can easily be replaced to add things like widget attributes.
+*  You can define a model that will allow you to save additional settings for each form.
 *  Form submissions are also listed by their form which you can filter by date and are ordered by newest first.
 *  Files can also be submitted to the forms that are shown with the form submissions.
 *  A form and its fields can easily be copied to a new form.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,0 +1,42 @@
+Advanced Settings
+=================
+
+Some times there is a requirement to save additional data for each form.
+Such as details of where to email the form submission. When this is needed we have
+provided the means to define your own model.
+
+To enable this you need to declare a model that inherits from
+``wagtailstreamforms.models.AbstractFormSetting``:
+
+.. code-block:: python
+  
+    from wagtailstreamforms.models.abstract import AbstractFormSetting
+
+    class AdvancedFormSetting(AbstractFormSetting):
+        to_address = models.EmailField()
+
+Once that's done you need to add a setting to point to that model:
+
+.. code-block:: python
+
+    # the model defined to save advanced form settings
+    # in the format of 'app_label.model_class'.
+    # Model must inherit from 'wagtailstreamforms.models.AbstractFormSetting'.
+    WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL = 'myapp.AdvancedFormSetting'
+
+A button will appear on the Streamforms listing view ``Advanced`` which will
+allow you to edit that model.
+
+Usage
+-----
+
+The data saved can be used in :ref:`hooks` on the ``instance.advanced_settings`` property.
+
+.. code-block:: python
+
+    @register('process_form_submission')
+    def email_submission(instance, form):
+        send_mail(
+            ..
+            recipient_list=[instance.advanced_settings.to_address]
+        )

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -1,3 +1,5 @@
+.. _hooks:
+
 Submission Hooks
 ================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ What else is included?
    usage
    templates
    fields
+   advanced
    submission
    hooks
    permissions

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -11,6 +11,11 @@ Any settings with their defaults are listed below for quick reference.
     # the order of the forms area in the admin sidebar
     WAGTAILSTREAMFORMS_ADMIN_MENU_ORDER = None
 
+    # the model defined to save advanced form settings
+    # in the format of 'app_label.model_class'.
+    # Model must inherit from 'wagtailstreamforms.models.AbstractFormSetting'.
+    WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL = None
+
     # enable the built in hook to process form submissions
     WAGTAILSTREAMFORMS_ENABLE_FORM_PROCESSING = True
 

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,11 @@
+from django.db import models
+
+from wagtailstreamforms.models import AbstractFormSetting
+
+
+class ValidFormSettingsModel(AbstractFormSetting):
+    name = models.CharField(max_length=255)
+
+
+class InvalidFormSettingsModel(models.Model):
+    pass

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -5,6 +5,7 @@ from wagtailstreamforms.models import AbstractFormSetting
 
 class ValidFormSettingsModel(AbstractFormSetting):
     name = models.CharField(max_length=255)
+    number = models.IntegerField()
 
 
 class InvalidFormSettingsModel(models.Model):

--- a/tests/models/test_form.py
+++ b/tests/models/test_form.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.test import override_settings
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.core.models import Page
@@ -86,6 +87,7 @@ class ModelPropertyTests(AppTestCase):
             {'slug': ['Form with this Slug already exists.']}
         )
 
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL=None)
     def test_copy(self):
         copied = self.test_form.copy()
 
@@ -122,6 +124,17 @@ class ModelPropertyTests(AppTestCase):
         copied = self.test_form.copy()
 
         self.assertEqual(FormSubmission.objects.filter(form=copied).count(), 0)
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='tests.ValidFormSettingsModel')
+    def test_copy_copies_advanced_settings(self):
+        from wagtailstreamforms.utils import get_advanced_settings_model
+        SettingsModel = get_advanced_settings_model()
+
+        SettingsModel.objects.create(form=self.test_form, name='foo', number=1)
+
+        copied = self.test_form.copy()
+
+        SettingsModel.objects.get(form=copied, name='foo', number=1)
 
     def test_get_data_fields(self):
         expected_fields = [

--- a/tests/models/test_form_settings.py
+++ b/tests/models/test_form_settings.py
@@ -1,0 +1,27 @@
+from django.db import models
+
+from wagtailstreamforms.models import AbstractFormSetting, Form
+
+from . import ValidFormSettingsModel
+from ..test_case import AppTestCase
+
+
+class ModelGenericTests(AppTestCase):
+    fixtures = ['test']
+
+    def test_abstract(self):
+        self.assertTrue(AbstractFormSetting._meta.abstract)
+
+    def test_str(self):
+        model = ValidFormSettingsModel(form=Form.objects.get(pk=1))
+        self.assertEqual(model.__str__(), model.form.title)
+
+
+class ModelFieldTests(AppTestCase):
+
+    def test_form(self):
+        field = self.get_field(AbstractFormSetting, 'form')
+        self.assertModelField(field, models.OneToOneField)
+        self.assertEqual(field.remote_field.model, 'wagtailstreamforms.Form')
+        self.assertEqual(field.remote_field.on_delete, models.CASCADE)
+        self.assertEqual(field.remote_field.related_name, 'advanced_settings')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -71,3 +71,5 @@ ROOT_URLCONF = 'tests.urls'
 STATIC_URL = '/static/'
 
 LOGIN_URL = reverse_lazy('admin:login')
+
+WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL = 'tests.ValidFormSettingsModel'

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -1,4 +1,6 @@
+import sys
 from contextlib import contextmanager
+from importlib import reload, import_module
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import models, connection
@@ -45,6 +47,11 @@ class AppTestCase(TestCase):
             yield
         finally:
             hooks._hooks[hook_name].remove((fn, order))
+
+    def reload_module(self, path):
+        if path in sys.modules:
+            reload(sys.modules[path])
+        return import_module(path)
 
     def render_template(self, string, context=None):
         context = context or {}

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,18 @@
+from django.test import override_settings
+
+from wagtailstreamforms.urls import urlpatterns
+
+from .test_case import AppTestCase
+
+
+class UrlsTests(AppTestCase):
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL=None)
+    def test_no_advanced_url_when_no_setting(self):
+        self.reload_module('wagtailstreamforms.urls')
+        self.assertEqual(len(urlpatterns), 3)
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='tests.ValidFormSettingsModel')
+    def test_no_advanced_url_when_no_setting(self):
+        self.reload_module('wagtailstreamforms.urls')
+        self.assertEqual(len(urlpatterns), 4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django.test import override_settings
+
+from tests.models import ValidFormSettingsModel
+from wagtailstreamforms.utils import get_advanced_settings_model
+
+from .test_case import AppTestCase
+
+
+class AdvancedSettingsTests(AppTestCase):
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL=None)
+    def test_default_none(self):
+        self.assertIsNone(get_advanced_settings_model())
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='foo')
+    def test_invalid_string(self):
+        msg = "must be of the form 'app_label.model_name'"
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            get_advanced_settings_model()
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='foo.Bar')
+    def test_invalid_import(self):
+        msg = "refers to model 'foo.Bar' that has not been installed"
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            get_advanced_settings_model()
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='tests.InvalidFormSettingsModel')
+    def test_invalid_model_inheritance(self):
+        msg = "must inherit from 'wagtailstreamforms.models.AbstractFormSetting'"
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            get_advanced_settings_model()
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='tests.ValidFormSettingsModel')
+    def test_valid_model_returns_class(self):
+        self.assertIs(get_advanced_settings_model(), ValidFormSettingsModel)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,12 +3,10 @@ from django.contrib import admin
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
-from wagtailstreamforms import urls as streamforms_urls
 
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^cms/', include(wagtailadmin_urls)),
-    url(r'^forms/', include(streamforms_urls)),
     url(r'', include(wagtail_urls)),
 ]

--- a/tests/views/test_admin_list.py
+++ b/tests/views/test_admin_list.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User, Permission
+from django.test import override_settings
 
 from ..test_case import AppTestCase
 
@@ -11,6 +12,7 @@ class AdminListViewTestCase(AppTestCase):
         self.access_admin = Permission.objects.get(codename='access_admin')
         self.add_perm = Permission.objects.get(codename='add_form')
         self.change_perm = Permission.objects.get(codename='change_form')
+        self.delete_perm = Permission.objects.get(codename='delete_form')
         self.client.login(username='user', password='password')
 
     def test_get_responds(self):
@@ -30,3 +32,29 @@ class AdminListViewTestCase(AppTestCase):
         response = self.client.get('/cms/wagtailstreamforms/form/')
         self.assertEqual(response.status_code, 200)
         self.assertIn('title="Copy this form">Copy</a>', str(response.content))
+
+    @override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='tests.ValidFormSettingsModel')
+    def test_advanced_button_enabled_when_setup(self):
+        url = '/cms/wagtailstreamforms/form/'
+        expected_html = 'title="Advanced settings">Advanced</a>'
+
+        # disabled with delete perm
+        self.user.user_permissions.add(self.access_admin, self.delete_perm)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(expected_html, str(response.content))
+
+        # enabled with add perm
+        self.user.user_permissions.remove(self.delete_perm)
+        self.user.user_permissions.add(self.add_perm)
+
+        response = self.client.get(url)
+        self.assertIn(expected_html, str(response.content))
+
+        # enabled with change perm
+        self.user.user_permissions.remove(self.add_perm)
+        self.user.user_permissions.add(self.change_perm)
+
+        response = self.client.get(url)
+        self.assertIn(expected_html, str(response.content))

--- a/tests/views/test_admin_list.py
+++ b/tests/views/test_admin_list.py
@@ -23,10 +23,10 @@ class AdminListViewTestCase(AppTestCase):
 
         response = self.client.get('/cms/wagtailstreamforms/form/')
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn('title="Copy this Form">Copy</a>', str(response.content))
+        self.assertNotIn('title="Copy this form">Copy</a>', str(response.content))
 
         self.user.user_permissions.add(self.access_admin, self.add_perm)
 
         response = self.client.get('/cms/wagtailstreamforms/form/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn('title="Copy this Form">Copy</a>', str(response.content))
+        self.assertIn('title="Copy this form">Copy</a>', str(response.content))

--- a/tests/views/test_advanced.py
+++ b/tests/views/test_advanced.py
@@ -1,0 +1,38 @@
+from django.contrib.auth.models import User, Permission
+from django.test import override_settings
+from django.urls import reverse
+from wagtailstreamforms.wagtail_hooks import FormURLHelper
+
+from wagtailstreamforms.models import Form
+
+from ..test_case import AppTestCase
+
+
+@override_settings(WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL='tests.ValidFormSettingsModel')
+class AdvancedSettingsViewTestCase(AppTestCase):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        User.objects.create_superuser('user', 'user@test.com', 'password')
+        self.form = Form.objects.get(pk=1)
+        self.advanced_url = reverse('wagtailstreamforms:streamforms_advanced', kwargs={'pk': self.form.pk})
+        self.client.login(username='user', password='password')
+
+    def test_get_responds(self):
+        response = self.client.get(self.advanced_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_invalid_form_responds(self):
+        response = self.client.post(self.advanced_url, data={})
+        self.assertEqual(response.status_code, 200)
+        self.assertInHTML('This field is required.', str(response.content))
+
+    def test_valid_post(self):
+        response = self.client.post(self.advanced_url, data={'name': 'foo'}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.form.advanced_settings.name, 'foo')
+
+    def test_post_redirects(self):
+        response = self.client.post(self.advanced_url, data={'name': 'foo'})
+        url_helper = FormURLHelper(model=Form)
+        self.assertRedirects(response, url_helper.index_url)

--- a/tests/views/test_advanced.py
+++ b/tests/views/test_advanced.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User, Permission
+from django.contrib.auth.models import User
 from django.test import override_settings
 from django.urls import reverse
 from wagtailstreamforms.wagtail_hooks import FormURLHelper
@@ -28,11 +28,11 @@ class AdvancedSettingsViewTestCase(AppTestCase):
         self.assertInHTML('This field is required.', str(response.content))
 
     def test_valid_post(self):
-        response = self.client.post(self.advanced_url, data={'name': 'foo'}, follow=True)
+        response = self.client.post(self.advanced_url, data={'name': 'foo', 'number': 1}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.form.advanced_settings.name, 'foo')
 
     def test_post_redirects(self):
-        response = self.client.post(self.advanced_url, data={'name': 'foo'})
+        response = self.client.post(self.advanced_url, data={'name': 'foo', 'number': 1})
         url_helper = FormURLHelper(model=Form)
         self.assertRedirects(response, url_helper.index_url)

--- a/wagtailstreamforms/conf.py
+++ b/wagtailstreamforms/conf.py
@@ -6,6 +6,7 @@ SETTINGS_PREFIX = 'WAGTAILSTREAMFORMS'
 SETTINGS_DEFAULTS = {
     'ADMIN_MENU_LABEL': _('Streamforms'),
     'ADMIN_MENU_ORDER': None,
+    'ADVANCED_SETTINGS_MODEL': None,
     'ENABLE_FORM_PROCESSING': True,
     'FORM_TEMPLATES': (
         ('streamforms/form_block.html', 'Default Form Template'),

--- a/wagtailstreamforms/models/__init__.py
+++ b/wagtailstreamforms/models/__init__.py
@@ -1,3 +1,4 @@
+from .abstract import AbstractFormSetting
 from .file import FormSubmissionFile
 from .form import Form
 from .submission import FormSubmission

--- a/wagtailstreamforms/models/abstract.py
+++ b/wagtailstreamforms/models/abstract.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+
+class AbstractFormSetting(models.Model):
+    form = models.OneToOneField(
+        'wagtailstreamforms.Form',
+        on_delete=models.CASCADE,
+        related_name='advanced_settings'
+    )
+
+    class Meta:
+        abstract = True
+
+    def __str__(self):
+        return self.form.title

--- a/wagtailstreamforms/models/form.py
+++ b/wagtailstreamforms/models/form.py
@@ -17,7 +17,7 @@ from wagtailstreamforms.streamfield import FormFieldsStreamField
 from wagtailstreamforms.conf import get_setting
 from wagtailstreamforms.fields import HookSelectField
 from wagtailstreamforms.forms import FormBuilder
-from wagtailstreamforms.utils import get_slug_from_string
+from wagtailstreamforms.utils import get_slug_from_string, get_advanced_settings_model
 
 from .submission import FormSubmission
 
@@ -121,6 +121,18 @@ class Form(models.Model):
             process_form_submission_hooks=self.process_form_submission_hooks
         )
         form_copy.save()
+
+        # additionally copy the advanced settings if they exist
+        SettingsModel = get_advanced_settings_model()
+
+        if SettingsModel:
+            try:
+                advanced = SettingsModel.objects.get(form=self)
+                advanced.pk = None
+                advanced.form = form_copy
+                advanced.save()
+            except SettingsModel.DoesNotExist:
+                pass
 
         return form_copy
 

--- a/wagtailstreamforms/templates/streamforms/advanced_settings.html
+++ b/wagtailstreamforms/templates/streamforms/advanced_settings.html
@@ -1,14 +1,13 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with form_title=object.title|capfirst %}Copy of {{ form_title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with form_title=object %}Advanced form settings for {{ form_title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-explorer{% endblock %}
 
 {% block content %}
-    {% trans "Copy" as copy_str %}
-    {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=object.title icon="doc-empty-inverse" %}
+    {% trans "Advanced form settings" as title_str %}
+    {% include "wagtailadmin/shared/header.html" with title=title_str subtitle=object icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
-        <p>{% trans 'Are you sure you want to copy this form?' %}</p>
         <form action="." method="POST" novalidate>
             {% csrf_token %}
             <ul class="fields">
@@ -18,7 +17,7 @@
                     {% endfor %}
                 {% endblock %}
                 <li>
-                    <input type="submit" value="{% trans 'Copy' %}" class="button" />
+                    <input type="submit" value="{% trans 'Save' %}" class="button" />
                 </li>
             </ul>
         </form>

--- a/wagtailstreamforms/urls.py
+++ b/wagtailstreamforms/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
 ]
 
 
-if SettingsModel:
+if SettingsModel:  # pragma: no cover
     urlpatterns += [
         path('<int:pk>/advanced/', views.AdvancedSettingsView.as_view(), name='streamforms_advanced'),
     ]

--- a/wagtailstreamforms/urls.py
+++ b/wagtailstreamforms/urls.py
@@ -1,11 +1,20 @@
 from django.urls import path
 
 from wagtailstreamforms import views
+from wagtailstreamforms.utils import get_advanced_settings_model
+
+
+SettingsModel = get_advanced_settings_model()
 
 
 urlpatterns = [
-    path('<int:pk>/advanced/', views.AdvancedSettingsView.as_view(), name='streamforms_advanced'),
     path('<int:pk>/copy/', views.CopyFormView.as_view(), name='streamforms_copy'),
     path('<int:pk>/submissions/', views.SubmissionListView.as_view(), name='streamforms_submissions'),
     path('<int:pk>/submissions/delete/', views.SubmissionDeleteView.as_view(), name='streamforms_delete_submissions'),
 ]
+
+
+if SettingsModel:
+    urlpatterns += [
+        path('<int:pk>/advanced/', views.AdvancedSettingsView.as_view(), name='streamforms_advanced'),
+    ]

--- a/wagtailstreamforms/urls.py
+++ b/wagtailstreamforms/urls.py
@@ -4,6 +4,7 @@ from wagtailstreamforms import views
 
 
 urlpatterns = [
+    path('<int:pk>/advanced/', views.AdvancedSettingsView.as_view(), name='streamforms_advanced'),
     path('<int:pk>/copy/', views.CopyFormView.as_view(), name='streamforms_copy'),
     path('<int:pk>/submissions/', views.SubmissionListView.as_view(), name='streamforms_submissions'),
     path('<int:pk>/submissions/delete/', views.SubmissionDeleteView.as_view(), name='streamforms_delete_submissions'),

--- a/wagtailstreamforms/utils.py
+++ b/wagtailstreamforms/utils.py
@@ -1,9 +1,39 @@
 from importlib import import_module
+
+from django.core.exceptions import ImproperlyConfigured
 from unidecode import unidecode
 
 from django.apps import apps
 from django.utils.module_loading import module_has_submodule
 from django.utils.text import slugify
+
+from wagtailstreamforms.conf import get_setting
+from wagtailstreamforms.models.abstract import AbstractFormSetting
+
+
+def get_advanced_settings_model():
+    """
+    Returns the advanced form settings model if one is defined
+    """
+
+    model = get_setting('ADVANCED_SETTINGS_MODEL')
+
+    if not model:
+        return
+
+    def raise_error(msg):
+        setting = 'WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL'
+        raise ImproperlyConfigured('%s %s' % (setting, msg))
+
+    try:
+        model_class = apps.get_model(model, require_ready=False)
+        if issubclass(model_class, AbstractFormSetting):
+            return model_class
+        raise_error("must inherit from 'wagtailstreamforms.models.AbstractFormSetting'")
+    except ValueError:
+        raise_error("must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise_error("refers to model '%s' that has not been installed" % model)
 
 
 def get_app_modules():

--- a/wagtailstreamforms/views/__init__.py
+++ b/wagtailstreamforms/views/__init__.py
@@ -1,3 +1,4 @@
+from .advanced_settings import AdvancedSettingsView
 from .copy import CopyFormView
 from .submission_delete import SubmissionDeleteView
 from .submission_list import SubmissionListView

--- a/wagtailstreamforms/views/advanced_settings.py
+++ b/wagtailstreamforms/views/advanced_settings.py
@@ -1,0 +1,33 @@
+from django import forms
+from django.views.generic import UpdateView
+
+from wagtailstreamforms.utils import get_advanced_settings_model
+from wagtailstreamforms.wagtail_hooks import FormURLHelper
+from wagtailstreamforms.models import Form
+
+
+SettingsModel = get_advanced_settings_model()
+
+
+class AdvancedSettingsForm(forms.ModelForm):
+    class Meta:
+        exclude = ('form',)
+        model = SettingsModel
+
+
+class AdvancedSettingsView(UpdateView):
+    form_class = AdvancedSettingsForm
+    model = SettingsModel
+    template_name = 'streamforms/advanced_settings.html'
+
+    @property
+    def url_helper(self):
+        return FormURLHelper(model=Form)
+
+    def get_object(self, queryset=None):
+        form = Form.objects.get(pk=self.kwargs.get('pk'))
+        obj, created = self.model.objects.get_or_create(form=form)
+        return obj
+
+    def get_success_url(self):
+        return self.url_helper.index_url

--- a/wagtailstreamforms/views/advanced_settings.py
+++ b/wagtailstreamforms/views/advanced_settings.py
@@ -1,5 +1,7 @@
 from django import forms
+from django.contrib import messages
 from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext as _
 from django.views.generic import UpdateView
 
 from wagtailstreamforms.utils import get_advanced_settings_model
@@ -20,6 +22,7 @@ class AdvancedSettingsView(UpdateView):
     form_class = AdvancedSettingsForm
     model = SettingsModel
     template_name = 'streamforms/advanced_settings.html'
+    success_message = _("Form '%s' advanced settings updated.")
 
     @property
     def url_helper(self):
@@ -30,6 +33,15 @@ class AdvancedSettingsView(UpdateView):
         form = get_object_or_404(Form, pk=pk)
         obj, created = self.model.objects.get_or_create(form=form)
         return obj
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        self.create_success_message()
+        return response
+
+    def create_success_message(self):
+        success_message = self.success_message % self.object.form
+        messages.success(self.request, success_message)
 
     def get_success_url(self):
         return self.url_helper.index_url

--- a/wagtailstreamforms/views/advanced_settings.py
+++ b/wagtailstreamforms/views/advanced_settings.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.shortcuts import get_object_or_404
 from django.views.generic import UpdateView
 
 from wagtailstreamforms.utils import get_advanced_settings_model
@@ -25,7 +26,8 @@ class AdvancedSettingsView(UpdateView):
         return FormURLHelper(model=Form)
 
     def get_object(self, queryset=None):
-        form = Form.objects.get(pk=self.kwargs.get('pk'))
+        pk = self.kwargs.get('pk')
+        form = get_object_or_404(Form, pk=pk)
         obj, created = self.model.objects.get_or_create(form=form)
         return obj
 

--- a/wagtailstreamforms/views/advanced_settings.py
+++ b/wagtailstreamforms/views/advanced_settings.py
@@ -29,9 +29,14 @@ class AdvancedSettingsView(UpdateView):
         return FormURLHelper(model=Form)
 
     def get_object(self, queryset=None):
-        pk = self.kwargs.get('pk')
-        form = get_object_or_404(Form, pk=pk)
-        obj, created = self.model.objects.get_or_create(form=form)
+        form_pk = self.kwargs.get('pk')
+        form = get_object_or_404(Form, pk=form_pk)
+
+        try:
+            obj = self.model.objects.get(form=form)
+        except self.model.DoesNotExist:
+            obj = self.model(form=form)
+
         return obj
 
     def form_valid(self, form):

--- a/wagtailstreamforms/views/copy.py
+++ b/wagtailstreamforms/views/copy.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
@@ -23,6 +24,7 @@ class CopyForm(forms.Form):
 class CopyFormView(SingleObjectTemplateResponseMixin, BaseDetailView):
     model = Form
     template_name = 'streamforms/confirm_copy.html'
+    success_message = _("Form '%s' copied to '%s'.")
 
     @property
     def permission_helper(self):
@@ -53,6 +55,8 @@ class CopyFormView(SingleObjectTemplateResponseMixin, BaseDetailView):
 
             copied.save()
 
+            self.create_success_message(copied)
+
             return HttpResponseRedirect(self.get_success_url())
 
         context = self.get_context_data(object=self.object)
@@ -68,6 +72,10 @@ class CopyFormView(SingleObjectTemplateResponseMixin, BaseDetailView):
 
     def post(self, request, *args, **kwargs):
         return self.copy(request, *args, **kwargs)
+
+    def create_success_message(self, copied):
+        success_message = self.success_message % (self.object, copied)
+        messages.success(self.request, success_message)
 
     def get_success_url(self):
         return self.url_helper.index_url

--- a/wagtailstreamforms/wagtail_hooks.py
+++ b/wagtailstreamforms/wagtail_hooks.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.contrib.admin.utils import quote
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.urls import path, reverse_lazy
+from django.urls import path, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.contrib.modeladmin.helpers import AdminURLHelper, ButtonHelper
@@ -20,18 +20,13 @@ SettingsModel = get_advanced_settings_model()
 
 class FormURLHelper(AdminURLHelper):
     def get_action_url(self, action, *args, **kwargs):
-        if action == 'advanced':
-            return reverse_lazy('wagtailstreamforms:streamforms_advanced', args=args, kwargs=kwargs)
-        elif action == 'copy':
-            return reverse_lazy('wagtailstreamforms:streamforms_copy', args=args, kwargs=kwargs)
-        elif action == 'submissions':
-            return reverse_lazy('wagtailstreamforms:streamforms_submissions', args=args, kwargs=kwargs)
+        if action in ['advanced', 'copy', 'submissions']:
+            return reverse('wagtailstreamforms:streamforms_%s' % action, args=args, kwargs=kwargs)
 
         return super().get_action_url(action, *args, **kwargs)
 
 
 class FormButtonHelper(ButtonHelper):
-
     def button(self, pk, action, label, title, classnames_add, classnames_exclude):
         cn = self.finalise_classname(classnames_add, classnames_exclude)
         button = {

--- a/wagtailstreamforms/wagtail_hooks.py
+++ b/wagtailstreamforms/wagtail_hooks.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.contrib.admin.utils import quote
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.urls import reverse, path
+from django.urls import path, reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.contrib.modeladmin.helpers import AdminURLHelper, ButtonHelper
@@ -21,63 +21,74 @@ SettingsModel = get_advanced_settings_model()
 class FormURLHelper(AdminURLHelper):
     def get_action_url(self, action, *args, **kwargs):
         if action == 'advanced':
-            return reverse('wagtailstreamforms:streamforms_advanced', args=args, kwargs=kwargs)
+            return reverse_lazy('wagtailstreamforms:streamforms_advanced', args=args, kwargs=kwargs)
         elif action == 'copy':
-            return reverse('wagtailstreamforms:streamforms_copy', args=args, kwargs=kwargs)
+            return reverse_lazy('wagtailstreamforms:streamforms_copy', args=args, kwargs=kwargs)
         elif action == 'submissions':
-            return reverse('wagtailstreamforms:streamforms_submissions', args=args, kwargs=kwargs)
+            return reverse_lazy('wagtailstreamforms:streamforms_submissions', args=args, kwargs=kwargs)
 
         return super().get_action_url(action, *args, **kwargs)
 
 
 class FormButtonHelper(ButtonHelper):
 
-    def advanced_button(self, pk, classnames_add=[], classnames_exclude=[]):
+    def button(self, pk, action, label, title, classnames_add, classnames_exclude):
         cn = self.finalise_classname(classnames_add, classnames_exclude)
         button = {
-            'url': self.url_helper.get_action_url('advanced', quote(pk)),
-            'label': _('Advanced'),
+            'url': self.url_helper.get_action_url(action, quote(pk)),
+            'label': label,
             'classname': cn,
-            'title': _('Advanced settings'),
+            'title': title,
         }
-        return button
 
-    def copy_button(self, pk, classnames_add=[], classnames_exclude=[]):
-        cn = self.finalise_classname(classnames_add, classnames_exclude)
-        button = {
-            'url': self.url_helper.get_action_url('copy', quote(pk)),
-            'label': _('Copy'),
-            'classname': cn,
-            'title': _('Copy this form'),
-        }
-        return button
-
-    def submissions_button(self, pk, classnames_add=[], classnames_exclude=[]):
-        cn = self.finalise_classname(classnames_add, classnames_exclude)
-        button = {
-            'url': self.url_helper.get_action_url('submissions', quote(pk)),
-            'label': _('Submissions'),
-            'classname': cn,
-            'title': _('Submissions of this form'),
-        }
         return button
 
     def get_buttons_for_obj(self, obj, exclude=None, classnames_add=None, classnames_exclude=None):
-        btns = super().get_buttons_for_obj(obj, exclude, classnames_add, classnames_exclude)
+        buttons = super().get_buttons_for_obj(obj, exclude, classnames_add, classnames_exclude)
         pk = getattr(obj, self.opts.pk.attname)
         ph = self.permission_helper
         usr = self.request.user
 
+        # if there is a form settings model defined
         # users that either create or edit forms should be able edit advanced settings
         if SettingsModel and (ph.user_can_create(usr) or ph.user_can_edit_obj(usr, obj)):
-            btns.append(self.advanced_button(pk, classnames_add, classnames_exclude))
+            buttons.append(
+                self.button(
+                    pk,
+                    'advanced',
+                    _('Advanced'),
+                    _('Advanced settings'),
+                    classnames_add,
+                    classnames_exclude
+                )
+            )
+
         # users that can create forms can copy them
         if ph.user_can_create(usr):
-            btns.append(self.copy_button(pk, classnames_add, classnames_exclude))
-        # users that can do any form actions can vies submissions
-        btns.append(self.submissions_button(pk, classnames_add, classnames_exclude))
+            buttons.append(
+                self.button(
+                    pk,
+                    'copy',
+                    _('Copy'),
+                    _('Copy this form'),
+                    classnames_add,
+                    classnames_exclude
+                )
+            )
 
-        return btns
+        # users that can do any form actions can vies submissions
+        buttons.append(
+            self.button(
+                pk,
+                'submissions',
+                _('Submissions'),
+                _('Submissions of this form'),
+                classnames_add,
+                classnames_exclude
+            )
+        )
+
+        return buttons
 
 
 @modeladmin_register


### PR DESCRIPTION
This allows the user to specify a form settings model in their own code base that must inherit from `wagtailstreamforms.models.AbstractFormSetting` and will enable end users to save additional data such as email settings against each form.

Model Example:
```
from wagtailstreamforms.models.abstract import AbstractFormSetting

class AdvancedFormSetting(AbstractFormSetting):
    name = models.CharField(
        max_length=255
    )
```
and in settings:

```
WAGTAILSTREAMFORMS_ADVANCED_SETTINGS_MODEL = 'example.AdvancedFormSetting' 
```

this will then enable the advanced button on each form:

![screen shot 2018-06-13 at 08 54 01](https://user-images.githubusercontent.com/20105514/41337554-6f688e40-6ee7-11e8-8c20-b227902bf6d3.png)

which will give an edit screen to update the settings:

![screen shot 2018-06-13 at 08 54 20](https://user-images.githubusercontent.com/20105514/41337566-791bbe8a-6ee7-11e8-8520-669fd3a3c086.png)

these settings will then be available in all form processing hooks a user defines:

```
@register('process_form_submission')
def test_advanced_settings(instance, form):
    print(instance.advanced_settings.name)
```