### PR TITLE
allow built in form processing hooks to be disabled

### DIFF
--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -9,6 +9,8 @@ The only defined one is that to save the form submission data.
 .. literalinclude:: ../wagtailstreamforms/wagtailstreamforms_hooks.py
    :pyobject: save_form_submission_data
 
+You can disable this by setting `WAGTAILSTREAMFORMS_ENABLE_BUILTIN_HOOKS=False` in your `settings.py`
+
 Create your own hook
 --------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -19,6 +19,10 @@ Any settings with their defaults are listed below for quick reference.
     # enable the built in hook to process form submissions
     WAGTAILSTREAMFORMS_ENABLE_FORM_PROCESSING = True
 
+    # enable the built in hooks defined in wagtailstreamforms
+    # currently (save_form_submission_data)
+    WAGTAILSTREAMFORMS_ENABLE_BUILTIN_HOOKS = True
+
     # the default form template choices
     WAGTAILSTREAMFORMS_FORM_TEMPLATES = (
         ('streamforms/form_block.html', 'Default Form Template'),

--- a/tests/hooks/test_registering.py
+++ b/tests/hooks/test_registering.py
@@ -1,4 +1,8 @@
+from django.test import override_settings
+
 from wagtailstreamforms import hooks
+from wagtailstreamforms.wagtailstreamforms_hooks import save_form_submission_data
+
 from ..test_case import AppTestCase
 
 
@@ -31,3 +35,24 @@ class TestHookRegistering(AppTestCase):
         with self.register_hook('test_hook_name', after_hook, order=1):
             hook_fns = hooks.get_hooks('test_hook_name')
             self.assertEqual(hook_fns, [test_hook, after_hook])
+
+
+class TestHookDefaults(AppTestCase):
+
+    def test_default_hooks(self):
+        hook_fns = hooks.get_hooks('process_form_submission')
+        self.assertEqual(hook_fns, [save_form_submission_data])
+
+    @override_settings(WAGTAILSTREAMFORMS_ENABLE_BUILTIN_HOOKS=False)
+    def test_builtins_can_be_disabled(self):
+        hook_fns = hooks.get_hooks('process_form_submission')
+        self.assertEqual(hook_fns, [])
+
+    @override_settings(WAGTAILSTREAMFORMS_ENABLE_BUILTIN_HOOKS=False)
+    def test_setting_only_removes_builtins(self):
+        def custom_hook():
+            pass
+
+        with self.register_hook('process_form_submission', custom_hook, order=1):
+            hook_fns = hooks.get_hooks('process_form_submission')
+            self.assertEqual(hook_fns, [custom_hook])

--- a/wagtailstreamforms/conf.py
+++ b/wagtailstreamforms/conf.py
@@ -8,6 +8,7 @@ SETTINGS_DEFAULTS = {
     'ADMIN_MENU_ORDER': None,
     'ADVANCED_SETTINGS_MODEL': None,
     'ENABLE_FORM_PROCESSING': True,
+    'ENABLE_BUILTIN_HOOKS': True,
     'FORM_TEMPLATES': (
         ('streamforms/form_block.html', 'Default Form Template'),
     ),

--- a/wagtailstreamforms/hooks.py
+++ b/wagtailstreamforms/hooks.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
 
+from wagtailstreamforms.conf import get_setting
 from wagtailstreamforms.utils.apps import get_app_submodules
 
 
@@ -46,4 +47,15 @@ def get_hooks(hook_name):
     search_for_hooks()
     hooks = _hooks.get(hook_name, [])
     hooks = sorted(hooks, key=itemgetter(1))
-    return [hook[0] for hook in hooks]
+    fncs = []
+    builtin_hook_modules = ['wagtailstreamforms.wagtailstreamforms_hooks']
+    builtin_enabled = get_setting('ENABLE_BUILTIN_HOOKS')
+
+    for fn, _ in hooks:
+        # dont add the hooks if they have been disabled via the setting
+        # this is so that they can be overridden
+        if fn.__module__ in builtin_hook_modules and not builtin_enabled:
+            continue
+        fncs.append(fn)
+
+    return fncs


### PR DESCRIPTION
This is so that you can disable any hooks defined internally allowing the end dev to provide only their own hooks:

```
# enable the built in hooks defined in wagtailstreamforms
# currently (save_form_submission_data)
WAGTAILSTREAMFORMS_ENABLE_BUILTIN_HOOKS = True  # default
```