### PR TITLE
load internal fields via a settings dict

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -24,6 +24,12 @@ The various default options for the fields are set when choosing that type of fi
 For example a dropdown includes options to set the ``choices`` and an additional ``empty_label`` as the
 first choice.
 
+Removing the package's default fields
+-------------------------------------
+
+If for some reason you dont want to use some of the default fields you can override the setting
+``WAGTAILSTREAMFORMS_DEFAULT_FIELDS``. Please see :ref:`settings` for the defaults.
+
 Adding new fields
 -----------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,3 +1,5 @@
+.. _settings:
+
 Settings
 ========
 
@@ -27,3 +29,23 @@ Any settings with their defaults are listed below for quick reference.
     WAGTAILSTREAMFORMS_FORM_TEMPLATES = (
         ('streamforms/form_block.html', 'Default Form Template'),
     )
+
+    # the default set of fields loaded from the package
+    # override this to remove unrequired fields
+    WAGTAILSTREAMFORMS_DEFAULT_FIELDS = {
+        'singleline': 'wagtailstreamforms.fields.SingleLineTextField',
+        'multiline': 'wagtailstreamforms.fields.MultiLineTextField',
+        'date': 'wagtailstreamforms.fields.DateField',
+        'datetime': 'wagtailstreamforms.fields.DateTimeField',
+        'email': 'wagtailstreamforms.fields.EmailField',
+        'url': 'wagtailstreamforms.fields.URLField',
+        'number': 'wagtailstreamforms.fields.NumberField',
+        'dropdown': 'wagtailstreamforms.fields.DropdownField',
+        'multiselect': 'wagtailstreamforms.fields.MultiSelectField',
+        'radio': 'wagtailstreamforms.fields.RadioField',
+        'checkboxes': 'wagtailstreamforms.fields.CheckboxesField',
+        'checkbox': 'wagtailstreamforms.fields.CheckboxField',
+        'hidden': 'wagtailstreamforms.fields.HiddenField',
+        'singlefile': 'wagtailstreamforms.fields.SingleFileField',
+        'multifile': 'wagtailstreamforms.fields.MultiFileField'
+    }

--- a/tests/fields/test_fields.py
+++ b/tests/fields/test_fields.py
@@ -1,7 +1,7 @@
 from django import forms
 
 from wagtailstreamforms.models import Form
-from wagtailstreamforms import wagtailstreamforms_fields as wsf_fields
+from wagtailstreamforms.fields import fields as wsf_fields
 from ..test_case import AppTestCase
 
 

--- a/tests/fields/test_registering.py
+++ b/tests/fields/test_registering.py
@@ -15,7 +15,7 @@ class TestFieldRegistering(AppTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del fields._fields['myfield']
+        del fields.base._fields['myfield']
 
     def test_field(self):
         self.assertIn('myfield', fields.get_fields())

--- a/tests/fields/test_streamfield.py
+++ b/tests/fields/test_streamfield.py
@@ -19,7 +19,7 @@ class TestCorrectTypeRegistering(AppTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del fields._fields['good']
+        del fields.base._fields['good']
 
     def test_child_blocks(self):
         field = FormFieldsStreamField([])
@@ -45,7 +45,7 @@ class TestIncorrectTypeRegistering(AppTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del fields._fields['bad']
+        del fields.base._fields['bad']
 
     def test_is_invalid_class(self):
         expected_error = "'%s' must be a subclass of '%s'" % (BadField, fields.BaseField)

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -36,7 +36,7 @@ class AppTestCase(TestCase):
         try:
             yield
         finally:
-            fields._fields[field_type].remove(cls)
+            fields.base._fields[field_type].remove(cls)
 
     @contextmanager
     def register_hook(self, hook_name, fn, order=0):

--- a/wagtailstreamforms/conf.py
+++ b/wagtailstreamforms/conf.py
@@ -12,6 +12,23 @@ SETTINGS_DEFAULTS = {
     'FORM_TEMPLATES': (
         ('streamforms/form_block.html', 'Default Form Template'),
     ),
+    'DEFAULT_FIELDS': {
+        'singleline': 'wagtailstreamforms.fields.SingleLineTextField',
+        'multiline': 'wagtailstreamforms.fields.MultiLineTextField',
+        'date': 'wagtailstreamforms.fields.DateField',
+        'datetime': 'wagtailstreamforms.fields.DateTimeField',
+        'email': 'wagtailstreamforms.fields.EmailField',
+        'url': 'wagtailstreamforms.fields.URLField',
+        'number': 'wagtailstreamforms.fields.NumberField',
+        'dropdown': 'wagtailstreamforms.fields.DropdownField',
+        'multiselect': 'wagtailstreamforms.fields.MultiSelectField',
+        'radio': 'wagtailstreamforms.fields.RadioField',
+        'checkboxes': 'wagtailstreamforms.fields.CheckboxesField',
+        'checkbox': 'wagtailstreamforms.fields.CheckboxField',
+        'hidden': 'wagtailstreamforms.fields.HiddenField',
+        'singlefile': 'wagtailstreamforms.fields.SingleFileField',
+        'multifile': 'wagtailstreamforms.fields.MultiFileField'
+    }
 }
 
 

--- a/wagtailstreamforms/fields/__init__.py
+++ b/wagtailstreamforms/fields/__init__.py
@@ -1,0 +1,24 @@
+from .base import (
+    BaseField,
+    get_fields,
+    HookMultiSelectFormField,
+    HookSelectField,
+    register
+)
+from .fields import (
+    CheckboxField,
+    CheckboxesField,
+    DateField,
+    DateTimeField,
+    DropdownField,
+    EmailField,
+    HiddenField,
+    MultiFileField,
+    MultiLineTextField,
+    MultiSelectField,
+    NumberField,
+    RadioField,
+    SingleFileField,
+    SingleLineTextField,
+    URLField
+)

--- a/wagtailstreamforms/fields/base.py
+++ b/wagtailstreamforms/fields/base.py
@@ -6,7 +6,8 @@ from django.utils.text import capfirst
 from wagtail.core import blocks
 
 from wagtailstreamforms import hooks
-from wagtailstreamforms.utils.apps import get_app_submodules
+from wagtailstreamforms.conf import get_setting
+from wagtailstreamforms.utils.apps import get_app_submodules, get_class
 
 
 _fields = {}
@@ -34,6 +35,13 @@ def register(field_name, cls=None):
     _fields[field_name] = cls
 
 
+def load_internal_fields():
+    field_classes = get_setting('DEFAULT_FIELDS')
+    for name, field_class in field_classes.items():
+        klass = get_class(field_class)
+        register(name, klass)
+
+
 def search_for_fields():
     global _searched_for_fields
     if not _searched_for_fields:
@@ -43,7 +51,7 @@ def search_for_fields():
 
 def get_fields():
     """ Return the registered field classes. """
-
+    load_internal_fields()
     search_for_fields()
     return _fields
 

--- a/wagtailstreamforms/fields/fields.py
+++ b/wagtailstreamforms/fields/fields.py
@@ -5,54 +5,46 @@ from wagtail.core import blocks
 from wagtailstreamforms.fields import BaseField, register
 
 
-@register('singleline')
 class SingleLineTextField(BaseField):
     field_class = forms.CharField
     label = _("Text field (single line)")
 
 
-@register('multiline')
 class MultiLineTextField(BaseField):
     field_class = forms.CharField
     widget = forms.widgets.Textarea
     label = _("Text field (multi line)")
 
 
-@register('date')
 class DateField(BaseField):
     field_class = forms.DateField
     icon = 'date'
     label = _("Date field")
 
 
-@register('datetime')
 class DateTimeField(BaseField):
     field_class = forms.DateTimeField
     icon = 'time'
     label = _("Time field")
 
 
-@register('email')
 class EmailField(BaseField):
     field_class = forms.EmailField
     icon = 'mail'
     label = _("Email field")
 
 
-@register('url')
 class URLField(BaseField):
     field_class = forms.URLField
     icon = 'link'
     label = _("URL field")
 
 
-@register('number')
 class NumberField(BaseField):
     field_class = forms.DecimalField
     label = _("Number field")
 
 
-@register('dropdown')
 class DropdownField(BaseField):
     field_class = forms.ChoiceField
     icon = 'arrow-down-big'
@@ -76,7 +68,6 @@ class DropdownField(BaseField):
         ], icon=self.icon, label=self.label)
 
 
-@register('multiselect')
 class MultiSelectField(BaseField):
     field_class = forms.MultipleChoiceField
     icon = 'list-ul'
@@ -97,7 +88,6 @@ class MultiSelectField(BaseField):
         ], icon=self.icon, label=self.label)
 
 
-@register('radio')
 class RadioField(BaseField):
     field_class = forms.ChoiceField
     widget = forms.widgets.RadioSelect
@@ -119,7 +109,6 @@ class RadioField(BaseField):
         ], icon=self.icon, label=self.label)
 
 
-@register('checkboxes')
 class CheckboxesField(BaseField):
     field_class = forms.MultipleChoiceField
     widget = forms.widgets.CheckboxSelectMultiple
@@ -141,7 +130,6 @@ class CheckboxesField(BaseField):
         ], icon=self.icon, label=self.label)
 
 
-@register('checkbox')
 class CheckboxField(BaseField):
     field_class = forms.BooleanField
     icon = 'tick-inverse'
@@ -155,7 +143,6 @@ class CheckboxField(BaseField):
         ], icon=self.icon, label=self.label)
 
 
-@register('hidden')
 class HiddenField(BaseField):
     field_class = forms.CharField
     widget = forms.widgets.HiddenInput
@@ -163,7 +150,6 @@ class HiddenField(BaseField):
     label = _("Hidden field")
 
 
-@register('singlefile')
 class SingleFileField(BaseField):
     field_class = forms.FileField
     widget = forms.widgets.FileInput
@@ -178,7 +164,6 @@ class SingleFileField(BaseField):
         ], icon=self.icon, label=self.label)
 
 
-@register('multifile')
 class MultiFileField(BaseField):
     field_class = forms.FileField
     widget = forms.widgets.FileInput(attrs={'multiple': True})

--- a/wagtailstreamforms/utils/apps.py
+++ b/wagtailstreamforms/utils/apps.py
@@ -23,3 +23,11 @@ def get_app_submodules(submodule_name):
     for name, module in get_app_modules():
         if module_has_submodule(module, submodule_name):
             yield name, import_module('%s.%s' % (name, submodule_name))
+
+
+def get_class(name):
+    components = name.split('.')
+    mod = __import__(components[0])
+    for comp in components[1:]:
+        mod = getattr(mod, comp)
+    return mod


### PR DESCRIPTION
currently this is just an idea and would resolve #109.

This means that internal fields are now not loaded as part of the register method, giving the end dev the ability to remove fields all together. so we could do the below and only have 3 selectable field types

```
WAGTAILSTREAMFORMS_DEFAULT_FIELDS = {
    'singleline': 'wagtailstreamforms.fields.SingleLineTextField',
    'multiline': 'wagtailstreamforms.fields.MultiLineTextField',
    'dropdown': 'wagtailstreamforms.fields.DropdownField'
}
```