### PR TITLE
Fix HookStreamField serialisation

### DIFF
--- a/wagtailstreamforms/fields.py
+++ b/wagtailstreamforms/fields.py
@@ -157,6 +157,10 @@ class HookSelectField(models.Field):
             return value
         return value.split(',')
 
+    def value_to_string(self, obj):
+        value = self.value_from_object(obj)
+        return ','.join(value)
+
     def validate(self, value, model_instance):
         arr_choices = [v for v, s in self.get_choices_default()]
         for opt in value:


### PR DESCRIPTION
Prior to this change, serialising Form models would result in the `repr` of the list in the `process_form_submission_hooks` field being written into JSON/XML/Yaml, and would not be interpreted correctly when loaded. Subsequent serialisations would then result in compounding of escape characters in the value, making quite a mess.